### PR TITLE
Addresses all standing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,8 @@ If you want to define multiple users, here are the steps to follow.
 to give the accounts 'tony' and 'jack' full access.
 
 
+If you want to allow non-admins access to specific plugin pages:
+
+    define('SEPARATE_USERS_ALLOWED_PLUGIN_PAGES', serialize(array('plugin_slug0', 'plugin_slug')));
+
 Please note: currently this plugin is designed mainly to clean up the admin interface for different users, and doesn't guarantee there's no way for one user to influence or access the links of another!  

--- a/README.md
+++ b/README.md
@@ -1,23 +1,50 @@
+YOURLS-Seperate-Users
+=====================
+
 A simple YouRLS plug to hide different users information from each other. 
 
-To install, just copy the plugins/separate-users folder to your plugins folder (usually user/plugins). Once activated, any new links created will only be visible in the admin to the user that created them, and the + stats page will also be restricted to only the user that created it. Users cannot create shortcodes the same as one already created by another user. 
+Features
+--------
+-  Links created by an authenticated user will only be visible in the admin area to that user (also `+` stats pages)
+-  If public, links created by non-authenticated users will be accessible to all users in the admin area (also `+` stats pages)
+-  Configurable `admin` account is able to access all links (but cannot yet see what user created them)
+-  Main plugin management page is restricted to admin users
+-  Individual plugin pages are restricted to admin users by default. Can be overridden by variable
+-  Filter allows other plugins to make individual plugin pages visible to all users
 
-If an account named 'admin' is created, it will be able to view all links. The specific name can be changed by defining SEPARATE_USERS_ADMIN_USER in the config, e.g. 
+Installation
+------------
+Copy the `separate-users` folder into the `/path/to/YOURLS/user/plugins/` folder. Activate in the admin area.
 
-    define ('SEPARATE_USERS_ADMIN_USER', 'tony');
+Configuration
+-------------
+To allow a user named Tony admin access, add the following to `config.php`:
+```
+$seperate_users_admin_user = array(
+	'Tony',
+	'admin'
+);
+```
+To allow the page for the `Sample Page` plugin included in YOURLS to be accessible to all users:
+```
+$seperate_users_allowed_plugin_pages = array(
+	'sample_page',
+	'some_other_plugin'
+);
+```
 
-to give the account 'tony' full access.
+Hooking into the filter
+-----------------------
+To allow a plugin with a plugin page slug of `my_page_slug` to be visible by default, add something like this to your code:
+```
+yourls_add_filter('seperate_users_allowed_plugin_pages', 'my_snappy_function' );
+function my_snappy_function( $allowed_pages ) {
 
+	$allowed_pages[] = 'my_page_slug';
 
-If you want to define multiple users, here are the steps to follow.
+	return $allowed_pages;
+}
 
-    define('SEPARATE_USERS_ADMIN_USER', serialize(array('tony', 'jack')));
-
-to give the accounts 'tony' and 'jack' full access.
-
-
-If you want to allow non-admins access to specific plugin pages:
-
-    define('SEPARATE_USERS_ALLOWED_PLUGIN_PAGES', serialize(array('plugin_slug0', 'plugin_slug')));
-
-Please note: currently this plugin is designed mainly to clean up the admin interface for different users, and doesn't guarantee there's no way for one user to influence or access the links of another!  
+```
+#### Please note: 
+Currently this plugin is designed mainly to clean up the admin interface for different users, and doesn't guarantee there's no way for one user to influence or access the links of another!  

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ YOURLS-Seperate-Users
 
 A simple YouRLS plug to hide different users information from each other. 
 
+Notice
+------
+This plugin will work well on it's own, but has been merged with and is depreicated by [Auth Manager Plus](https://github.com/joshp23/YOURLS-AuthMgrPlus), which provides Role Based Access Control. The decision was to merge these plugins rather than to simply integrate them for the sake of simplicity and to avoid redundancy.
+
 Features
 --------
 -  Links created by an authenticated user will only be visible in the admin area to that user (also `+` stats pages)

--- a/plugins/separate-users/plugin.php
+++ b/plugins/separate-users/plugin.php
@@ -266,7 +266,7 @@ function seperate_users_intercept_admin() {
 			if ( isset( $_REQUEST['page'] ) ) {
 				$action_keyword = $_REQUEST['page'];
 				$allowed = unserialize(SEPARATE_USERS_ALLOWED_PLUGIN_PAGES);
-				if(!in_array($link, $allowed) ) {
+				if(!in_array($action_keyword, $allowed) ) {
 					yourls_redirect( yourls_admin_url( '?access=denied' ), 302 );
 				}
 			}

--- a/plugins/separate-users/plugin.php
+++ b/plugins/separate-users/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Separate Users
 Plugin URI: https://github.com/ianbarber/Yourls-Separate-Users
 Description: Allow some filtering of URLs based on the user that created them
-Version: 0.4.0
+Version: 0.4.1
 Author: Ian Barber <ian.barber@gmail.com>
 Author URI: http://phpir.com/
 */
@@ -251,18 +251,26 @@ function seperate_users_intercept_admin() {
 				$admin = true;
 		}
 
-		// restrict access to non-admins
+		// restrict access to plugin mgmt non-admins
 		if( !$admin ) {
-			// intercept requests for plugin management page
+			// intercept requests for global plugin management page
 			if( isset( $_SERVER['REQUEST_URI'] ) && $_SERVER['REQUEST_URI'] == '/admin/plugins.php' ||
 				// intercept requests for plugin management 
 				isset( $_REQUEST['plugin'] ) ) {
 				yourls_redirect( yourls_admin_url( '?access=denied' ), 302 );
 			}
-		}
+			// intercept requests for individual plugin management pages
+			if ( isset( $_REQUEST['page'] ) ) {
+				$action_keyword = $_REQUEST['page'];
+				$allowed = unserialize(SEPARATE_USERS_ALLOWED_PLUGIN_PAGES);
+				if(!in_array($link, $allowed) ) {
+					yourls_redirect( yourls_admin_url( '?access=denied' ), 302 );
+				}
+			}
+		}	
 	}
 }
-
+// remove disallowed plugins from link list
 function separate_users_admin_sublinks( $links ) {
 	$user = YOURLS_USER; 
 	// admin check
@@ -276,7 +284,7 @@ function separate_users_admin_sublinks( $links ) {
 			$admin = true;
 	}
 
-	// restrict access to non-admins
+	// restrict access to non-admins - removes from link list
 	if( !$admin ) {
 
 		$allowed = unserialize(SEPARATE_USERS_ALLOWED_PLUGIN_PAGES);

--- a/plugins/separate-users/plugin.php
+++ b/plugins/separate-users/plugin.php
@@ -1,9 +1,9 @@
 <?php
 /*
 Plugin Name: Separate Users
-Plugin URI: http://virgingroupdigital.wordpress.com
+Plugin URI: https://github.com/ianbarber/Yourls-Separate-Users
 Description: Allow some filtering of URLs based on the user that created them
-Version: 0.3
+Version: 0.4.0
 Author: Ian Barber <ian.barber@gmail.com>
 Author URI: http://phpir.com/
 */
@@ -42,9 +42,12 @@ if(!defined('SEPARATE_USERS_ADMIN_USER')) {
 
 yourls_add_action( 'insert_link', 'separate_users_insert_link' );
 yourls_add_action( 'activated_separate-users/plugin.php', 'separate_users_activated' );
+yourls_add_action( 'auth_successful', 'seperate_users_intercept_admin' );
 yourls_add_filter( 'admin_list_where', 'separate_users_admin_list_where' );
 yourls_add_filter( 'is_valid_user', 'separate_users_is_valid_user' );
 yourls_add_filter( 'api_url_stats', 'separate_users_api_url_stats' );
+yourls_add_filter( 'get_db_stats', 'separate_users_get_db_stats' );
+yourls_add_filter( 'admin_sublinks', 'separate_users_admin_sublinks' );
 
 /**
  * Activate the plugin, and add the user column to the table if not added
@@ -52,18 +55,35 @@ yourls_add_filter( 'api_url_stats', 'separate_users_api_url_stats' );
  * @param array $args 
  */
 function separate_users_activated($args) {
-        global $ydb; 
+	global $ydb; 
         
-        $table = YOURLS_DB_TABLE_URL;
-	$results = $ydb->get_results("DESCRIBE $table");
+	$table = YOURLS_DB_TABLE_URL;
+
+	if (version_compare(YOURLS_VERSION, '1.7.3') >= 0) {
+		$sql = "DESCRIBE `$table`";
+		$results = $ydb->fetchObjects($sql);
+	} else {
+		$results = $ydb->get_results("DESCRIBE $table");
+	}
+
 	$activated = false;
 	foreach($results as $r) {
-	        if($r->Field == 'user') {
-	                $activated = true;
-	        }
+		if($r->Field == 'user') {
+			$activated = true;
+		}
 	}
 	if(!$activated) {
-		$ydb->query("ALTER TABLE `$table` ADD `user` VARCHAR(255) NULL");
+
+		if (version_compare(YOURLS_VERSION, '1.7.3') >= 0) {
+			$binds = null;
+			$sql = "ALTER TABLE `$table` ADD `user` VARCHAR(255) NULL)";
+			$insert = $ydb->fetchAffected($sql,$binds);
+
+		} else {
+
+			$ydb->query("ALTER TABLE `$table` ADD `user` VARCHAR(255) NULL");
+
+		}
 	}
 }
 
@@ -75,15 +95,15 @@ function separate_users_activated($args) {
  * @return array
  */
 function separate_users_api_url_stats( $return, $shorturl ) {
-        $keyword = str_replace( YOURLS_SITE . '/' , '', $shorturl ); // accept either 'http://ozh.in/abc' or 'abc'
+	$keyword = str_replace( YOURLS_SITE . '/' , '', $shorturl ); // accept either 'http://ozh.in/abc' or 'abc'
 	$keyword = yourls_sanitize_string( $keyword );
-        $keyword = addslashes($keyword);
+	$keyword = addslashes($keyword);
         
-        if(separate_users_is_valid($keyword)) {
-                return $return;
-        } else {
-                return array('simple' => "URL is owned by another user", 'message' => 'URL is owned by another user', 'errorCode' => 403);
-        }
+	if(separate_users_is_valid($keyword)) {
+		return $return;
+	} else {
+		return array('simple' => "URL is owned by another user", 'message' => 'URL is owned by another user', 'errorCode' => 403);
+	}
 }
 
 
@@ -94,13 +114,13 @@ function separate_users_api_url_stats( $return, $shorturl ) {
  * @return bool is_valid
  */
 function separate_users_is_valid_user($is_valid) {
-        global $keyword; 
-        
-        if(!$is_valid || !defined("YOURLS_INFOS")) {
-                return $is_valid;
-        }
+	global $keyword; 
 
-        return separate_users_is_valid($keyword) ? true : "Sorry, that URL was created by another user."; 
+	if(!$is_valid || !defined("YOURLS_INFOS")) {
+		return $is_valid;
+	}
+
+	return separate_users_is_valid($keyword) ? true : "Sorry, that URL was created by another user."; 
 }
 
 /**
@@ -109,14 +129,21 @@ function separate_users_is_valid_user($is_valid) {
  * @param array $actions 
  */
 function separate_users_insert_link($actions) {
-        global $ydb; 
-        
-        $keyword = $actions[2];
-        $user = addslashes(YOURLS_USER); // this is pretty noddy, could do with some better filtering/checking
-        $table = YOURLS_DB_TABLE_URL;
-        
-        // Insert $keyword against $username
-        $result = $ydb->query("UPDATE `$table` SET  `user` = '" . $user . "' WHERE `keyword` = '" . $keyword . "'");
+	global $ydb; 
+
+	$keyword = $actions[2];
+	$user = addslashes(YOURLS_USER); // this is pretty noddy, could do with some better filtering/checking
+	$table = YOURLS_DB_TABLE_URL;
+
+	// Insert $keyword against $username
+	if (version_compare(YOURLS_VERSION, '1.7.3') >= 0) {
+		$binds = array( 'user' => $user,
+						'keyword' => $keyword);
+		$sql = "UPDATE `$table` SET  `user` = :user WHERE `keyword` = :keyword";
+		$result = $ydb->fetchAffected($sql, $binds);
+	} else {
+		$result = $ydb->query("UPDATE `$table` SET  `user` = $user WHERE `keyword` = $keyword");
+	}
 }
 
 /**
@@ -126,21 +153,142 @@ function separate_users_insert_link($actions) {
  * @return string
  */
 function separate_users_admin_list_where($where) {
-        $user = addslashes(YOURLS_USER); 
-		if(!is_serialized(SEPARATE_USERS_ADMIN_USER)) { 
-			if($user == SEPARATE_USERS_ADMIN_USER) {
-				return $where; // Allow admin user to see the lot. 
-			}
-		} else { 
-			$SEPARATE_USERS_ADMIN_USER = unserialize(SEPARATE_USERS_ADMIN_USER);
-				if(in_array($user, $SEPARATE_USERS_ADMIN_USER)) {
-					return $where; // Allow admin user to see the lot. 
-				}
+	$user = YOURLS_USER; 
+	if(!is_serialized(SEPARATE_USERS_ADMIN_USER)) { 
+		if($user == SEPARATE_USERS_ADMIN_USER) {
+			return $where; // Allow admin user to see the lot. 
 		}
+	} else { 
+		$SEPARATE_USERS_ADMIN_USER = unserialize(SEPARATE_USERS_ADMIN_USER);
+		if(in_array($user, $SEPARATE_USERS_ADMIN_USER)) {
+			return $where; // Allow admin user to see the lot. 
+		}
+	}
 
-        return $where . " AND (`user` = '$user' OR `user` IS NULL) ";
+	if (version_compare(YOURLS_VERSION, '1.7.3') >= 0) {
+		$where['sql'] = $where['sql'] . " AND (`user` = :user OR `user` IS NULL) ";
+		$where['binds']['user'] = $user;
+	}
+	else
+		$where = $where . " AND (`user` = $user OR `user` IS NULL) ";
+
+	return $where;
 }
 
+/**
+ * Filter out db stats to user access lvl
+ *
+ * @param array $return
+ * @param array $where
+ * @return array 
+ */
+function separate_users_get_db_stats( $return, $where ) {
+
+	$user = YOURLS_USER; 
+
+	// admin check
+	if(!is_serialized(SEPARATE_USERS_ADMIN_USER)) { 
+		if($user == SEPARATE_USERS_ADMIN_USER) {
+			return $return; // Allow admin user to see the lot. 
+		}
+	} else { 
+		$SEPARATE_USERS_ADMIN_USER = unserialize(SEPARATE_USERS_ADMIN_USER);
+		if(in_array($user, $SEPARATE_USERS_ADMIN_USER)) {
+			return $return; // Allow admin user to see the lot. 
+		}
+	}
+
+	// filter results
+	global $ydb;
+	$table_url = YOURLS_DB_TABLE_URL;
+
+	if (version_compare(YOURLS_VERSION, '1.7.3') >= 0) {
+
+		$where['sql'] = $where['sql'] . " AND (`user` = :user OR `user` IS NULL) ";
+		$where['binds']['user'] = $user;
+
+		$sql = "SELECT COUNT(keyword) as count, SUM(clicks) as sum FROM `$table_url` WHERE 1=1 " . $where['sql'];
+		$binds = $where['binds'];
+
+		$totals = $ydb->fetchObject($sql, $binds);
+
+	} else {
+
+		$where = $where . " AND (`user` = $user OR `user` IS NULL) ";
+		$totals = $ydb->get_results("SELECT COUNT(keyword) as count, SUM(clicks) as sum FROM `$table_url` WHERE 1=1 " . $where );
+	}
+
+	$return = array( 'total_links' => $totals->count, 'total_clicks' => $totals->sum );
+
+	return $return;
+
+}
+
+/**
+ * Restricting Access to Plugin Administration(s) for non-admins
+ *
+ *  
+ *
+ *
+ */
+function seperate_users_intercept_admin() {
+	// we use this GET param to send up a feedback notice to user
+    if ( isset( $_GET['access'] ) && $_GET['access']=='denied' ) {
+    	yourls_add_notice('Access Denied');
+    }
+
+	// only worry about this with HTML draw
+	if(!yourls_is_API()) {
+		$user = YOURLS_USER; 
+		// admin check
+		$admin = false;
+		if(!is_serialized(SEPARATE_USERS_ADMIN_USER)) { 
+			if($user == SEPARATE_USERS_ADMIN_USER)
+				$admin = true;
+		} else { 
+			$SEPARATE_USERS_ADMIN_USER = unserialize(SEPARATE_USERS_ADMIN_USER);
+			if(in_array($user, $SEPARATE_USERS_ADMIN_USER))
+				$admin = true;
+		}
+
+		// restrict access to non-admins
+		if( !$admin ) {
+			// intercept requests for plugin management page
+			if( isset( $_SERVER['REQUEST_URI'] ) && $_SERVER['REQUEST_URI'] == '/admin/plugins.php' ||
+				// intercept requests for plugin management 
+				isset( $_REQUEST['plugin'] ) ) {
+				yourls_redirect( yourls_admin_url( '?access=denied' ), 302 );
+			}
+		}
+	}
+}
+
+function separate_users_admin_sublinks( $links ) {
+	$user = YOURLS_USER; 
+	// admin check
+	$admin = false;
+	if(!is_serialized(SEPARATE_USERS_ADMIN_USER)) { 
+		if($user == SEPARATE_USERS_ADMIN_USER)
+			$admin = true;
+	} else { 
+		$SEPARATE_USERS_ADMIN_USER = unserialize(SEPARATE_USERS_ADMIN_USER);
+		if(in_array($user, $SEPARATE_USERS_ADMIN_USER))
+			$admin = true;
+	}
+
+	// restrict access to non-admins
+	if( !$admin ) {
+
+		$allowed = unserialize(SEPARATE_USERS_ALLOWED_PLUGIN_PAGES);
+		foreach( $links['plugins'] as $link => $ar ) {
+			if(!in_array($link, $allowed) )
+				unset($links['plugins'][$link]);
+		}
+	}
+
+	sort($links['plugins']);
+	return $links;
+}
 /**
  * Internal module function for testing user access to a keyword
  *
@@ -149,21 +297,28 @@ function separate_users_admin_list_where($where) {
  * @return boolean
  */
 function separate_users_is_valid( $keyword ) {
-        global $ydb; 
-        
-        $user = addslashes(YOURLS_USER);
-		if(!is_serialized(SEPARATE_USERS_ADMIN_USER)) { 
-			if($user == SEPARATE_USERS_ADMIN_USER) {
-				return true;
-			}
-		} else { 
-			$SEPARATE_USERS_ADMIN_USER = unserialize(SEPARATE_USERS_ADMIN_USER);
-			if(in_array($user, $SEPARATE_USERS_ADMIN_USER)) {
-				return true;
-			}
-		}        
-       
-        $table = YOURLS_DB_TABLE_URL;
-        $result = $ydb->query("SELECT 1 FROM `$table` WHERE  (`user` IS NULL OR `user` = '" . $user . "') AND `keyword` = '" . $keyword . "'");
-        return $result > 0;
+	global $ydb; 
+    
+    $user = addslashes(YOURLS_USER);
+	if(!is_serialized(SEPARATE_USERS_ADMIN_USER)) { 
+		if($user == SEPARATE_USERS_ADMIN_USER) {
+			return true;
+		}
+	} else { 
+		$SEPARATE_USERS_ADMIN_USER = unserialize(SEPARATE_USERS_ADMIN_USER);
+		if(in_array($user, $SEPARATE_USERS_ADMIN_USER)) {
+			return true;
+		}
+	}
+
+	$table = YOURLS_DB_TABLE_URL;
+
+	if (version_compare(YOURLS_VERSION, '1.7.3') >= 0) {
+		$binds = array( 'keyword' => $keyword, 'user' => $user);
+		$sql = "SELECT 1 FROM `$table` WHERE  (`user` IS NULL OR `user` = :user) AND `keyword` = :keyword";
+		$result = $ydb->fetchAffected($sql, $binds);
+	} else
+    	$result = $ydb->query("SELECT 1 FROM `$table` WHERE  (`user` IS NULL OR `user` = $user) AND `keyword` = $keyword");
+
+	return $result > 0;
 }

--- a/plugins/separate-users/plugin.php
+++ b/plugins/separate-users/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Separate Users
 Plugin URI: https://github.com/ianbarber/Yourls-Separate-Users
 Description: Allow some filtering of URLs based on the user that created them
-Version: 0.4.1
+Version: 0.4.2
 Author: Ian Barber <ian.barber@gmail.com>
 Author URI: http://phpir.com/
 */
@@ -40,6 +40,9 @@ if(!defined('SEPARATE_USERS_ADMIN_USER')) {
 	define('SEPARATE_USERS_ADMIN_USER', serialize(array("admin")));
 }
 
+if(!defined('SEPARATE_USERS_ALLOWED_PLUGIN_PAGES')) {
+	define('SEPARATE_USERS_ALLOWED_PLUGIN_PAGES', serialize(array(null)));
+}
 yourls_add_action( 'insert_link', 'separate_users_insert_link' );
 yourls_add_action( 'activated_separate-users/plugin.php', 'separate_users_activated' );
 yourls_add_action( 'auth_successful', 'seperate_users_intercept_admin' );

--- a/separate-users/plugin.php
+++ b/separate-users/plugin.php
@@ -217,7 +217,7 @@ function seperate_users_intercept_admin() {
 			// intercept requests for individual plugin management pages
 			if ( isset( $_REQUEST['page'] ) ) {
 				$action_keyword = $_REQUEST['page'];
-				if(!in_array($action_keyword, $$env['pages']) ) {
+				if(!in_array($action_keyword, $env['pages']) ) {
 					yourls_redirect( yourls_admin_url( '?access=denied' ), 302 );
 				}
 			}

--- a/separate-users/plugin.php
+++ b/separate-users/plugin.php
@@ -7,7 +7,7 @@ Version: 1.1.0
 Author: Ian Barber <ian.barber@gmail.com>
 Author URI: http://phpir.com/
 */
-if((yourls_is_active_plugin('authmp/plugin.php')) !== false) {
+if((yourls_is_active_plugin('authMgrPlus/plugin.php')) !== false) {
 	die('Seperate Users is depricated to Auth Manager Plus.');
 }
 /**

--- a/separate-users/plugin.php
+++ b/separate-users/plugin.php
@@ -3,11 +3,13 @@
 Plugin Name: Separate Users
 Plugin URI: https://github.com/ianbarber/Yourls-Separate-Users
 Description: Allow some filtering of URLs based on the user that created them
-Version: 1.0.0
+Version: 1.1.0
 Author: Ian Barber <ian.barber@gmail.com>
 Author URI: http://phpir.com/
 */
-
+if((yourls_is_active_plugin('authmp/plugin.php')) !== false) {
+	die('Seperate Users is depricated to Auth Manager Plus.');
+}
 /**
  * Set the environment variables
  *
@@ -80,7 +82,7 @@ yourls_add_filter( 'api_url_stats', 'separate_users_api_url_stats' );
 function separate_users_api_url_stats( $return, $shorturl ) {
 	$keyword = str_replace( YOURLS_SITE . '/' , '', $shorturl ); // accept either 'http://ozh.in/abc' or 'abc'
 	$keyword = yourls_sanitize_string( $keyword );
-	$keyword = addslashes($keyword);
+	$keyword = $keyword;
 
 	if(separate_users_is_valid($keyword)) {
 		return $return;
@@ -96,14 +98,15 @@ function separate_users_api_url_stats( $return, $shorturl ) {
  * @param bool $is_valid 
  * @return bool is_valid
  */
-yourls_add_filter( 'is_valid_user', 'separate_users_is_valid_user' );
-function separate_users_is_valid_user($is_valid) {
-	global $keyword; 
-
-	if(!$is_valid || !defined("YOURLS_INFOS")) {
-		return $is_valid;
+yourls_add_action( 'pre_yourls_infos', 'separate_users_pre_yourls_infos' );
+function separate_users_pre_yourls_infos( $keyword ) {
+	if( !separate_users_is_valid($keyword) ) {
+		$authenticated = yourls_is_valid_user();
+		if ( $authenticated === true ) 
+				yourls_redirect( yourls_admin_url( '?access=denied' ), 302 );
+			else
+				yourls_redirect( YOURLS_SITE, 302 );
 	}
-	return separate_users_is_valid($keyword) ? true : "Sorry, that URL was created by another user."; 
 }
 
 /**

--- a/separate-users/plugin.php
+++ b/separate-users/plugin.php
@@ -41,7 +41,7 @@ function seperate_users_env() {
 yourls_add_action( 'activated_separate-users/plugin.php', 'separate_users_activated' );
 function separate_users_activated($args) {
 	global $ydb; 
-        
+    
 	$table = YOURLS_DB_TABLE_URL;
 	$version = version_compare(YOURLS_VERSION, '1.7.3') >= 0;
 
@@ -81,7 +81,7 @@ function separate_users_api_url_stats( $return, $shorturl ) {
 	$keyword = str_replace( YOURLS_SITE . '/' , '', $shorturl ); // accept either 'http://ozh.in/abc' or 'abc'
 	$keyword = yourls_sanitize_string( $keyword );
 	$keyword = addslashes($keyword);
-        
+
 	if(separate_users_is_valid($keyword)) {
 		return $return;
 	} else {
@@ -198,9 +198,9 @@ function separate_users_get_db_stats( $return, $where ) {
 yourls_add_action( 'auth_successful', 'seperate_users_intercept_admin' );
 function seperate_users_intercept_admin() {
 	// we use this GET param to send up a feedback notice to user
-    if ( isset( $_GET['access'] ) && $_GET['access']=='denied' ) {
-    	yourls_add_notice('Access Denied');
-    }
+	if ( isset( $_GET['access'] ) && $_GET['access']=='denied' ) {
+		yourls_add_notice('Access Denied');
+	}
 	// only worry about this with HTML draw
 	if(!yourls_is_API()) {
 		$user = YOURLS_USER; 
@@ -265,7 +265,7 @@ function separate_users_is_valid( $keyword ) {
 		$sql = "SELECT 1 FROM `$table` WHERE  (`user` IS NULL OR `user` = :user) AND `keyword` = :keyword";
 		$result = $ydb->fetchAffected($sql, $binds);
 	} else
-    	$result = $ydb->query("SELECT 1 FROM `$table` WHERE  (`user` IS NULL OR `user` = $user) AND `keyword` = $keyword");
+		$result = $ydb->query("SELECT 1 FROM `$table` WHERE  (`user` IS NULL OR `user` = $user) AND `keyword` = $keyword");
 
 	return $result > 0;
 }


### PR DESCRIPTION
This clears up all issues in the que and then some:
-  compatibility with upcoming YOURLS 1.7.3 (maintains backwards compatibility)
-  restricts plugin management page to admins
-  configurable and robust protection of individual plugin pages
-  Exposed hook to filter allowed plugin pages by other plugins
-  fix global number of links & page numbers being exposed for each user in admin page
-  corrects plugin URL in plugin header (useful for [PUNS](https://github.com/joshp23/YOURLS-PUNS))
-  Trimmed redundancies and beautified code
-  Restructured config environment to streamline authorization
-  More informative README